### PR TITLE
Adding volume type parameter to work for cloudstack 4.16

### DIFF
--- a/pkg/cloud/instance.go
+++ b/pkg/cloud/instance.go
@@ -306,6 +306,7 @@ func (c *client) DestroyVMInstance(csMachine *infrav1.CloudStackMachine) error {
 func (c *client) listVMInstanceVolumeIDs(instanceID string) ([]string, error) {
 	p := c.cs.Volume.NewListVolumesParams()
 	p.SetVirtualmachineid(instanceID)
+	p.SetType("DATADISK")
 
 	listVOLResp, err := c.csAsync.Volume.ListVolumes(p)
 	if err != nil {

--- a/pkg/cloud/instance_test.go
+++ b/pkg/cloud/instance_test.go
@@ -439,6 +439,7 @@ var _ = Describe("Instance", func() {
 
 		It("calls destroy and finds VM doesn't exist, then returns nil", func() {
 			listVolumesParams.SetVirtualmachineid(*dummies.CSMachine1.Spec.InstanceID)
+			listVolumesParams.SetType("DATADISK")
 			vms.EXPECT().NewDestroyVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).
 				Return(expungeDestroyParams)
 			vms.EXPECT().DestroyVirtualMachine(expungeDestroyParams).Return(nil, fmt.Errorf("unable to find uuid for id"))
@@ -450,6 +451,7 @@ var _ = Describe("Instance", func() {
 
 		It("calls destroy and returns unexpected error", func() {
 			listVolumesParams.SetVirtualmachineid(*dummies.CSMachine1.Spec.InstanceID)
+			listVolumesParams.SetType("DATADISK")
 			vms.EXPECT().NewDestroyVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).
 				Return(expungeDestroyParams)
 			vms.EXPECT().DestroyVirtualMachine(expungeDestroyParams).Return(nil, fmt.Errorf("new error"))
@@ -460,6 +462,7 @@ var _ = Describe("Instance", func() {
 
 		It("calls destroy without error but cannot resolve VM after", func() {
 			listVolumesParams.SetVirtualmachineid(*dummies.CSMachine1.Spec.InstanceID)
+			listVolumesParams.SetType("DATADISK")
 			vms.EXPECT().NewDestroyVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).
 				Return(expungeDestroyParams)
 			vms.EXPECT().DestroyVirtualMachine(expungeDestroyParams).Return(nil, nil)
@@ -473,6 +476,7 @@ var _ = Describe("Instance", func() {
 
 		It("calls destroy without error and identifies it as expunging", func() {
 			listVolumesParams.SetVirtualmachineid(*dummies.CSMachine1.Spec.InstanceID)
+			listVolumesParams.SetType("DATADISK")
 			vms.EXPECT().NewDestroyVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).
 				Return(expungeDestroyParams)
 			vms.EXPECT().DestroyVirtualMachine(expungeDestroyParams).Return(nil, nil)
@@ -488,6 +492,7 @@ var _ = Describe("Instance", func() {
 
 		It("calls destroy without error and identifies it as expunged", func() {
 			listVolumesParams.SetVirtualmachineid(*dummies.CSMachine1.Spec.InstanceID)
+			listVolumesParams.SetType("DATADISK")
 			vms.EXPECT().NewDestroyVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).
 				Return(expungeDestroyParams)
 			vms.EXPECT().DestroyVirtualMachine(expungeDestroyParams).Return(nil, nil)
@@ -503,6 +508,7 @@ var _ = Describe("Instance", func() {
 
 		It("calls destroy without error and identifies it as stopping", func() {
 			listVolumesParams.SetVirtualmachineid(*dummies.CSMachine1.Spec.InstanceID)
+			listVolumesParams.SetType("DATADISK")
 			vms.EXPECT().NewDestroyVirtualMachineParams(*dummies.CSMachine1.Spec.InstanceID).
 				Return(expungeDestroyParams)
 			vms.EXPECT().DestroyVirtualMachine(expungeDestroyParams).Return(nil, nil)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Without this change, when I tested CAPC deletion against a 4.16 environment, I was observing the async deletion request hang, and log error 

```
(logid:224d9b4e) Complete async job-26801, jobStatus: FAILED, resultCode: 530, result: org.apache.cloudstack.api.response.ExceptionResponse/null/{"uuidList":[],"errorcode":"431","errortext":"The following supplied volumes are not DATADISK attached to the VM: Vol[3269|vm=3266|ROOT]; "}
```

I discussed with some colleagues and they suggested making this change.

*Testing performed:*
Unit tests pass locally. Successfully created and deleted a cloudstack cluster with eks-a in ACS 4.16 and 4.14 using this commit


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->